### PR TITLE
docs: fix docs documentation dependencies

### DIFF
--- a/.github/workflows/spalah_docs.yaml
+++ b/.github/workflows/spalah_docs.yaml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Dependencies
-        run: uv sync --group docs
+        run: uv sync --group docs; uv pip install -e .
 
       - name: Prepare branch gh-pages
         if: ${{false}}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ theme:
   palette:    
     # Palette toggle for light mode
     - scheme: default
-      primary: deep purple
+      primary: blue grey
       accent: indigo
       toggle:
         icon: material/weather-sunny

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 license = "MIT"
 keywords = ["spalah"]
-classifiers = ["Intended Audience :: Developers", "Natural Language :: English", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3.7", "Programming Language :: Python :: 3.8", "Programming Language :: Python :: 3.9", "Programming Language :: Python :: 3.10"]
+classifiers = ["Intended Audience :: Developers", "Natural Language :: English", "Programming Language :: Python :: 3",  "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12" ]
 readme = "README.md"
 requires-python = ">=3.11.0,<4.0.0"
 
@@ -35,7 +35,7 @@ dev = [
     "twine==4.0.1",
     "watchdog==2.1.9",
     "wheel==0.43.0",
-    "pytest-sugar==1.1",
+    "pytest-sugar==1.1.1",
     "python-semantic-release==10.5.3",
 ]
 
@@ -73,10 +73,6 @@ mask_initial_release = true
 [tool.ruff]
 line-length = 100
 fix = true
-
-
-
-
 
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
This pull request includes several minor updates focused on improving documentation workflows, updating project metadata, and making small configuration adjustments. The most notable changes involve updating Python version support, improving the documentation build process, and making minor theme and dependency tweaks.

**Project metadata and compatibility:**
* Updated `pyproject.toml` to add support for Python 3.11 and 3.12, and removed support for Python 3.7, 3.8, 3.9, and 3.10 in the `classifiers` list.
* Updated the `pytest-sugar` development dependency from version 1.1 to 1.1.1 in `pyproject.toml`.

**Documentation and workflow improvements:**
* Modified the documentation workflow in `.github/workflows/spalah_docs.yaml` to install the package in editable mode after syncing dependencies, ensuring the docs build uses the local package code.

**Configuration and appearance:**
* Changed the primary color of the documentation theme from "deep purple" to "blue grey" in `mkdocs.yml`.
* Cleaned up unnecessary blank lines in the `pyproject.toml` configuration.