### PR TITLE
ci: add step to install uv in CD pipeline

### DIFF
--- a/.github/workflows/spalah_cd.yaml
+++ b/.github/workflows/spalah_cd.yaml
@@ -33,6 +33,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
       - name: Setup | Force release branch to be at workflow sha
         run: |
           git reset --hard ${{ github.sha }}


### PR DESCRIPTION
This pull request introduces a small update to the continuous deployment workflow by adding an installation step for the `uv` tool.

* DevOps/CI improvements:
  * [`.github/workflows/spalah_cd.yaml`](diffhunk://#diff-4d6aa3f5f734e9e1bc19bcf72b65ef30169ba7d254300df68103def81ebf7ec1R36-R38): Added a step to install `uv` using a shell script before proceeding with the rest of the workflow.