### PR TITLE
ci: update build command and add optional dependencies for uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dev = [
     "pytest-sugar==1.1.1",
 ]
 
+[project.optional-dependencies]
+build = ["uv ~= 0.9.25"]
 
 [tool.semantic_release]
 
@@ -44,7 +46,13 @@ no_git_verify = false
 tag_format = "v{version}"
 add_partial_tags = false
 
-build_command = "uv build"
+build_command = """
+    python -m pip install -e '.[build]'
+    uv lock --upgrade-package "$PACKAGE_NAME"
+    git add uv.lock
+    uv build
+"""
+
 branch = "main"
 version_toml = ["pyproject.toml:project.version"]
 changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
This pull request updates the build process configuration in `pyproject.toml` to improve dependency management and build reproducibility. The main changes involve introducing an optional dependency group for build tools and enhancing the build command to ensure all necessary dependencies are installed before building.

**Build process improvements:**

* Added a new `[project.optional-dependencies]` section with a `build` group that includes `uv`, making it easier to install build-specific dependencies when needed.
* Updated the `build_command` in the semantic release configuration to:
  * Install the package in editable mode with build dependencies.
  * Upgrade the lock file for the current package.
  * Add the updated lock file to git.
  * Build the package using `uv`.
  This ensures all build steps are reproducible and dependencies are properly managed.